### PR TITLE
DAT-3070: removed COLUMN_NONPII and COLUMNS_DROP from datastore_delta_event function

### DIFF
--- a/functions/datastore_delta_event/config.py.example
+++ b/functions/datastore_delta_event/config.py.example
@@ -39,14 +39,6 @@ STATE_STORAGE_SPECIFICATION = {
     'id_property': 'identifying_property'
 }
 
-# List of columns without personal data
-COLUMNS_NONPII = [
-]
-
-# List of columns to drop (for instance containing reporting date)
-COLUMNS_DROP = [
-]
-
 # Specification of attributes in published message. Key value will be key value
 # in the published message, value in COLUMNS_PUBLISH will be attribute in source from which
 # value of the respective field will be retrieved when using it as a string {[name]: [field]}.

--- a/functions/datastore_delta_event/main.py
+++ b/functions/datastore_delta_event/main.py
@@ -199,7 +199,7 @@ def publish_diff(data, context):
 
     bucket = data['bucket']
     filename = data['name']
-    df_new = None
+    new_data = None
 
     prefix_filter = config.FILEPATH_PREFIX_FILTER if hasattr(config, 'FILEPATH_PREFIX_FILTER') else None
     batch_message_size = config.BATCH_MESSAGE_SIZE if hasattr(config, 'BATCH_MESSAGE_SIZE') else None
@@ -252,7 +252,7 @@ def publish_diff(data, context):
 
             if config.INBOX != config.ARCHIVE:
                 # Write file to archive
-                df_to_store(config.ARCHIVE, filename, df_new)
+                df_to_store(config.ARCHIVE, filename, new_data)
                 # Remove file from inbox
                 remove_from_store(config.INBOX, filename)
 
@@ -260,7 +260,7 @@ def publish_diff(data, context):
 
         except Exception as e:
             if hasattr(config, 'ERROR'):
-                df_to_store(config.ERROR, filename, df_new)
+                df_to_store(config.ERROR, filename, new_data)
             if config.INBOX != config.ARCHIVE:
                 remove_from_store(config.INBOX, filename)
             logging.error('Processing failure {}'.format(e))

--- a/functions/datastore_delta_event/main.py
+++ b/functions/datastore_delta_event/main.py
@@ -16,6 +16,8 @@ from gathermsg import gather_publish_msg
 DATASTORE_CHUNK_SIZE = 300
 
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 batch_settings = pubsub_v1.types.BatchSettings(**config.TOPIC_BATCH_SETTINGS)
 publisher = pubsub.PublisherClient(batch_settings)

--- a/functions/datastore_delta_event/main.py
+++ b/functions/datastore_delta_event/main.py
@@ -69,8 +69,7 @@ def data_from_store(bucket_name, blob_name, from_archive=False):
         if from_archive:
             new_data = pd.read_excel(path, dtype=str).to_dict(orient='records')
         else:
-            converter = {i: str for i in range(len(config.COLUMNS_NONPII))}
-            new_data = pd.read_excel(path, converters=converter).to_dict(orient='records')
+            new_data = pd.read_excel(path, dtype=str).to_dict(orient='records')
     elif blob_name.endswith('.csv'):
         new_data = pd.read_csv(path, **config.CSV_DIALECT_PARAMETERS).to_dict(orient='records')
     elif blob_name.endswith('.atom'):

--- a/functions/datastore_delta_event/main.py
+++ b/functions/datastore_delta_event/main.py
@@ -16,8 +16,6 @@ from gathermsg import gather_publish_msg
 DATASTORE_CHUNK_SIZE = 300
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 batch_settings = pubsub_v1.types.BatchSettings(**config.TOPIC_BATCH_SETTINGS)
 publisher = pubsub.PublisherClient(batch_settings)
@@ -70,6 +68,7 @@ def data_from_store(bucket_name, blob_name, from_archive=False):
     if blob_name.endswith('.xlsx'):
         if from_archive:
             new_data = pd.read_excel(path, dtype=str).to_dict(orient='records')
+            print('new_data received')
         else:
             new_data = pd.read_excel(path, dtype=str).to_dict(orient='records')
     elif blob_name.endswith('.csv'):
@@ -84,6 +83,7 @@ def data_from_store(bucket_name, blob_name, from_archive=False):
             new_data = json_data[config.ATTRIBUTE_WITH_THE_LIST]
         else:
             new_data = pd.read_json(path, dtype=False).to_dict(orient='records')
+    print('Read file .....')
     logging.info('Read file {} from {}'.format(blob_name, bucket_name))
     return new_data
 
@@ -210,10 +210,12 @@ def publish_diff(data, context):
         try:
             # Read dataframe from store
             new_data = data_from_store(bucket, filename)
+            print('test1')
             state_storage_specification = config.STATE_STORAGE_SPECIFICATION
 
             if state_storage_specification['type'] == 'datastore':
                 rows_json = calculate_diff_from_datastore(new_data, state_storage_specification)
+                print('type of the json is {}'.format(type(rows_json)))
             else:
                 raise ValueError(f"Unknown state_storage type {state_storage_specification['type']}")
 
@@ -221,9 +223,10 @@ def publish_diff(data, context):
             # In case of no new records: don't send any updates
             if len(rows_json) == 0:
                 logging.info('No new rows found')
+                print('nothing new found')
             else:
                 logging.info('Found {} new rows.'.format(len(rows_json)))
-
+                print('some new lines found')
                 # Publish individual rows to topic
                 i = 1
                 datastore_new_state = {}
@@ -255,14 +258,16 @@ def publish_diff(data, context):
             if config.INBOX != config.ARCHIVE:
                 # Write file to archive
                 df_to_store(config.ARCHIVE, filename, new_data)
+                print('write file to archive')
                 # Remove file from inbox
                 remove_from_store(config.INBOX, filename)
-
+                print('reomve file from archive')
             logging.info('Run succeeded')
 
         except Exception as e:
             if hasattr(config, 'ERROR'):
                 df_to_store(config.ERROR, filename, new_data)
+                print('exception has occured')
             if config.INBOX != config.ARCHIVE:
                 remove_from_store(config.INBOX, filename)
             logging.error('Processing failure {}'.format(e))


### PR DESCRIPTION
Removed the NONPII and DROP columns parameters from the config.py.example because they where not used. Also replaced pd.read_excel converter to dtypes=str, because every column must be read as a str. The NONPII as indicator for the length was not working. 